### PR TITLE
added DOM render, button filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,12 +9,14 @@
 </head>
 <body>
   <div class="container">
-    <div id="pet-buttons" class="container mt-3 text-center">
-      <button type="button" class="btn btn-info text-white">Cats</button>
-      <button type="button" class="btn btn-success mx-5">Dogs</button>
-      <button type="button" class="btn btn-warning text-white">Dinos</button>
+    <div id="pet-buttons" class="container mt-3 mb-4 text-center">
+      <button type="button" class="btn btn-secondary text-white mx-2" id="all">All</button>
+      <button type="button" class="btn btn-info text-white mx-2" id="cat">Cats</button>
+      <button type="button" class="btn btn-success mx-2" id="dog">Dogs</button>
+      <button type="button" class="btn btn-warning text-white mx-2" id="dino">Dinos</button>
     </div>
-    <div id="pet-cards" class="d-flex flex-wrap justify-content-around">
+    <div id="pet-cards" class="d-flex flex-wrap justify-content-around"></div>
+    <!-- <div id="pet-cards" class="d-flex flex-wrap justify-content-around">
       <div class="card text-center card my-2" style="width: 18rem;">
         <div class="card-header fw-bold text-secondary">
          Name
@@ -28,7 +30,7 @@
         </div>
         <div id="dino-footer" class="card-footer"><p>Cat or Dog</p></div>
       </div>
-    </div>
+    </div> -->
   </div>
 
 

--- a/main.css
+++ b/main.css
@@ -8,19 +8,23 @@ img {
   height: 200px;
 }
 
-#cat-footer {
+.card-header {
+  height: 45px;
+}
+
+.cat-footer {
   background-color: rgba(5, 187, 247, 0.15);
   color: rgba(5, 187, 247, 1.0);
   height: 45px;
 }
 
-#dog-footer {
+.dog-footer {
   background-color:rgba(57, 125, 51, 0.15);
   color:rgba(57, 125, 51, 1.0);
   height: 45px;
 }
 
-#dino-footer {
+.dino-footer {
   background-color:rgba(232, 199, 14, 0.10);
   color: #ffae00;
   height: 45px;

--- a/main.js
+++ b/main.js
@@ -1,4 +1,3 @@
-console.log('CONNECTED')
 
 const pets = [
     {
@@ -13,7 +12,7 @@ const pets = [
       color: "Poop-Colored",
       specialSkill: "Just picks the tomatoes off of a sandwich instead of requesting a whole new sandwich.",
       type: "dino",
-      imageUrl: "http://www.jozilife.co.za/wp-content/uploads/The-Dino-Expo.jpg"
+      imageUrl: "https://images-na.ssl-images-amazon.com/images/I/81sCOFgpjkL._AC_SL1500_.jpg"
     },
     {
       name: "Whiskers",
@@ -55,7 +54,7 @@ const pets = [
       color: "Grey",
       specialSkill: "Comfortable in the outdoors for up to eight hours.",
       type: "dino",
-      imageUrl: "http://www.theouthousers.com/images/jck//ThanosCopter/news/grumpasaur.jpg"
+      imageUrl: "https://www.popsci.com/resizer/bMm9C-yuxfHrb2RubGevFZVY2U4=/760x506/filters:focal(960x640:961x641)/arc-anglerfish-arc2-prod-bonnier.s3.amazonaws.com/public/CDGDHC66UGCVYCTPKSWMWS3YII.jpg"
     },
     {
       name: "Sassy",
@@ -111,7 +110,7 @@ const pets = [
       color: "Poop-Colored",
       specialSkill: "Drives at a safe rate of speed in snow or rain.",
       type: "dino",
-      imageUrl: "https://images.readwrite.com/wp-content/uploads/2018/03/t-rex-dino-quiz-e1490854556549.jpg"
+      imageUrl: "https://i.pinimg.com/originals/8c/86/54/8c8654a568b7143a0ab6464361497480.jpg"
     },
     {
       name: "Muffin",
@@ -125,7 +124,7 @@ const pets = [
       color: "Poop-Colored",
       specialSkill: "Proficient in air guitar",
       type: "dino",
-      imageUrl: "https://www.nation.co.ke/image/view/-/4078922/highRes/1742693/-/maxw/600/-/1453yvh/-/DINO.jpg"
+      imageUrl: "https://cdn.the-scientist.com/assets/articleNo/36893/aImg/15927/humongous-herbivorous-dinosaur-l.jpg"
     },
     {
       name: "Callie",
@@ -146,21 +145,21 @@ const pets = [
       color: "Red",
       specialSkill: "Owns a Nintendo Power Glove.",
       type: "dino",
-      imageUrl: "https://img.buzzfeed.com/buzzfeed-static/static/2015-11/2/12/enhanced/webdr15/anigif_enhanced-29802-1446485228-10.gif?crop=250:165;0,0&downsize=715"
+      imageUrl: "https://static.boredpanda.com/blog/wp-content/uploads/2017/07/jurassic-park-dinosaurs-replaced-with-cats-16-5978351341fe8__700.jpg"
     },
     {
       name: "Snuggles",
       color: "Orange",
       specialSkill: "Is comfortable with jokes about his receding hairline.",
       type: "cat",
-      imageUrl: "http://funnyanimalphoto.com/wp-content/uploads/2013/08/cat_caught_mouse_thegatewaypundit.jpg"
+      imageUrl: "https://i0.wp.com/nypost.com/wp-content/uploads/sites/2/2018/08/180808-woman-seeks-orange-cat-feature.jpg?quality=80&strip=all&ssl=1"
     },
     {
       name: "Buddy",
       color: "Red",
       specialSkill: "Enjoys fine wine.",
       type: "dog",
-      imageUrl: "http://1.bp.blogspot.com/-VjM0CmtN-vU/T7YX-LXa09I/AAAAAAAADA0/Vt1oGWEG0lw/s1600/sheepdog+border+collie+shakes+off+water+funny+picture+photo+pulling+faces+raspberry+tongue.jpg"
+      imageUrl: "https://www.dog-breeds-expert.com/images/olde_english_bulldogge_laredo-txDOTamericanlistedDotcom.jpg"
     },
     {
       name: "George",
@@ -174,7 +173,7 @@ const pets = [
       color: "Red",
       specialSkill: "Knows the words to 4 rap songs.",
       type: "cat",
-      imageUrl: "http://funbk.s3.amazonaws.com/wp-content/uploads/2016/06/funny-cat-video-which-will-make-you-laugh-louder.jpg"
+      imageUrl: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTGHsC9pHvqy66WPMYgxFJLSxR7O2krtmrLdA&usqp=CAU"
     },
     {
       name: "Bubba",
@@ -209,6 +208,70 @@ const pets = [
       color: "Red",
       specialSkill: "Doesn’t get weirded out by the word “moist.”",
       type: "dino",
-      imageUrl: "http://lsae2.iypcdn.com/static//modules/uploads/photos/language1/dino-live-22.jpg?119"
+      imageUrl: "https://images.ctfassets.net/cnu0m8re1exe/70JhB0XIHJmprEsQmEIMx3/eee66f1505b8b1d53ff0f3b18b305a5e/shutterstock_1099958171.jpg?w=650&h=433&fit=fill"
     }
   ];
+
+  //  *** DOM Printer *** //
+const printToDom = (divId, textToPrint) => {
+  const selectedDiv = document.querySelector(divId);
+  selectedDiv.innerHTML = textToPrint;
+}
+
+  // *** HTML Builders *** //
+const petBuilder = (taco) => {
+  let domString = ''
+
+  for (const element of taco) {
+    domString += `<div class="card text-center card my-2" style="width: 18rem;">
+      <div class="card-header fw-bold text-secondary">
+       <p>${element.name}</p>
+      </div>
+      <div class="card-body">
+        <div class="card-img-holder">
+          <img class="img-thumbnail p-2" src="${element.imageUrl}" alt="a cat">
+        </div>
+        <h5 class="card-title pt-2">${element.color}</h5>
+        <p class="card-text">${element.specialSkill}</p>
+      </div>
+      <div class="card-footer ${element.type}-footer"><p>${element.type}</p></div>
+    </div>`;
+  }
+  printToDom('#pet-cards', domString)
+
+};
+
+  // *** Event Handlers *** //
+const handleButtonClick = (e) => {
+  const buttonId = e.target.id;
+  const newArray = [];
+
+  for (let i = 0; i < pets.length; i++) {
+    if (pets[i].type === buttonId) {
+      newArray.push(pets[i]);
+    }
+  }
+
+  if (buttonId === 'all') {
+    petBuilder(pets)
+  } else {
+    petBuilder(newArray);
+  }
+
+}
+  // *** Event Listeners *** //
+const buttonEvents = () => {
+  document.querySelector('#all').addEventListener('click', handleButtonClick);
+  document.querySelector('#cat').addEventListener('click', handleButtonClick);
+  document.querySelector('#dog').addEventListener('click', handleButtonClick);
+  document.querySelector('#dino').addEventListener('click', handleButtonClick);
+
+};
+
+  // *** Initializers *** //
+const init = () => {
+  petBuilder(pets);
+  buttonEvents();
+}
+
+init();


### PR DESCRIPTION
Rendered all pets for adoption, added button filter feature.
<!--- DELETE ALL COMMENTS BEFORE CREATING PULL REQUEST -->

## Description
App now renders all pets available for adoption. 
Buttons will now filter to pets of corresponding button type. 
Added button to reset to all available pets. 

## Related Issue
Issues 5-7

## Motivation and Context
This will display all pets available for adoption, matching the wireframe provided. 
The button filtering will allow the end user to sort by pet type. 

## How Can This Be Tested?
hs -o 
Ensure all pet cards load initially 
Click each button at the top of the app to test filtering by type
Reset by clicking the 'All' button

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
